### PR TITLE
More robust dependency detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/ractivejs/rcu",
   "dependencies": {
     "eval2": "^0.3.0",
+    "tippex": "^1.1.0",
     "vlq": "^0.2.0"
   },
   "devDependencies": {

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,3 +1,4 @@
+import { match } from 'tippex';
 import { Ractive } from './init.js';
 import getName from './getName.js';
 import getLinePosition from './utils/getLinePosition.js';
@@ -94,10 +95,9 @@ export default function parse ( source ) {
 
 		result.script = source.slice( contentStart, contentEnd );
 
-		let match;
-		while ( match = requirePattern.exec( result.script ) ) {
-			modules.push( match[1] || match[2] );
-		}
+		match( result.script, requirePattern, ( match, doubleQuoted, singleQuoted ) => {
+			modules.push( doubleQuoted || singleQuoted );
+		});
 	}
 
 	return result;

--- a/test/parse/input/commentedRequire.html
+++ b/test/parse/input/commentedRequire.html
@@ -1,0 +1,5 @@
+<h1>Hello world!</h1>
+
+<script>
+	// var foo = require( 'foo' );
+</script>

--- a/test/parse/output/commentedRequire.json
+++ b/test/parse/output/commentedRequire.json
@@ -1,0 +1,18 @@
+{
+	"source": "<h1>Hello world!</h1>\n\n<script>\n\t// var foo = require( 'foo' );\n</script>\n",
+	"template": {"v":3,"t":[{"t":7,"e":"h1","f":["Hello world!"],"p":[1,1,0]}]},
+	"script": "\n\t// var foo = require( 'foo' );\n",
+	"scriptEnd": {
+		"char": 64,
+		"column": 0,
+		"line": 4
+	},
+	"scriptStart": {
+		"char": 31,
+		"column": 8,
+		"line": 2
+	},
+	"css": "",
+	"imports": [],
+	"modules": []
+}


### PR DESCRIPTION
Fixes #4, by using [tippex](https://github.com/rich-harris/tippex) to ensure that `require` statements don't appear in strings or commented-out lines. Adds a couple of hundred lines to the build but I figure it's worth it, since it'll also mean we can manipulate source code with high confidence (e.g. rewriting `import` declarations as `require` statements, stuff like that) without having to add a bulky full-blown JS parser.