### PR TITLE
generate hires sourcemaps by default

### DIFF
--- a/src/generateSourceMap.js
+++ b/src/generateSourceMap.js
@@ -13,41 +13,67 @@ let alreadyWarned = false;
  * @param {string=} options.file - the name of the generated file
  * @returns {object}
  */
-export default function generateSourceMap ( definition, options ) {
-	if ( !options || !options.source ) {
-		throw new Error( 'You must supply an options object with a `source` property to rcu.generateSourceMap()' );
-	}
-
+export default function generateSourceMap ( definition, options = {} ) {
 	if ( 'padding' in options ) {
 		options.offset = options.padding;
 
 		if ( !alreadyWarned ) {
-			console.log( 'rcu: options.padding is deprecated, use options.offset instead' ); // eslint-disable-line no-console
+			console.warn( 'rcu: options.padding is deprecated, use options.offset instead' ); // eslint-disable-line no-console
 			alreadyWarned = true;
 		}
 	}
 
-	// The generated code probably includes a load of module gubbins - we don't bother
-	// mapping that to anything, instead we just have a bunch of empty lines
-	const offset = new Array( ( options.offset || 0 ) + 1 ).join( ';' );
+	let mappings = '';
 
-	const lines = definition.script.split( '\n' );
-	const mappings = offset + lines.map( ( line, i ) => {
-		if ( i === 0 ) {
-			// first mapping points to code immediately following opening <script> tag
-			return encode([ 0, 0, definition.scriptStart.line, definition.scriptStart.column ]);
+	if ( definition.scriptStart ) {
+		// The generated code probably includes a load of module gubbins - we don't bother
+		// mapping that to anything, instead we just have a bunch of empty lines
+		const offset = new Array( ( options.offset || 0 ) + 1 ).join( ';' );
+		const lines = definition.script.split( '\n' );
+
+		let encoded;
+
+		if ( options.hires !== false ) {
+			let previousLineEnd = -definition.scriptStart.column;
+
+			encoded = lines.map( ( line, i ) => {
+				const lineOffset = i === 0 ? definition.scriptStart.line : 1;
+
+				let encoded = encode([ 0, 0, lineOffset, -previousLineEnd ]);
+
+				const lineEnd = line.length;
+
+				for ( let j = 1; j < lineEnd; j += 1 ) {
+					encoded += ',CAAC';
+				}
+
+				previousLineEnd = i === 0 ?
+					lineEnd + definition.scriptStart.column :
+					Math.max( 0, lineEnd - 1 );
+
+				return encoded;
+			});
+		} else {
+			encoded = lines.map( ( line, i ) => {
+				if ( i === 0 ) {
+					// first mapping points to code immediately following opening <script> tag
+					return encode([ 0, 0, definition.scriptStart.line, definition.scriptStart.column ]);
+				}
+
+				if ( i === 1 ) {
+					return encode([ 0, 0, 1, -definition.scriptStart.column ]);
+				}
+
+				return 'AACA'; // equates to [ 0, 0, 1, 0 ];
+			});
 		}
 
-		if ( i === 1 ) {
-			return encode([ 0, 0, 1, -definition.scriptStart.column ]);
-		}
-
-		return 'AACA'; // equates to [ 0, 0, 1, 0 ];
-	}).join( ';' );
+		mappings = offset + encoded.join( ';' );
+	}
 
 	return new SourceMap({
-		file: options.file,
-		sources: [ options.source ],
+		file: options.file || null,
+		sources: [ options.source || null ],
 		sourcesContent: [ definition.source ],
 		names: [],
 		mappings

--- a/test/generateSourceMap/getLocation.js
+++ b/test/generateSourceMap/getLocation.js
@@ -1,0 +1,20 @@
+module.exports = function getLocation ( source, charIndex ) {
+	var lines = source.split( '\n' );
+	var len = lines.length;
+
+	var lineStart = 0;
+	var i;
+
+	for ( i = 0; i < len; i += 1 ) {
+		var line = lines[i];
+		var lineEnd =  lineStart + line.length + 1; // +1 for newline
+
+		if ( lineEnd > charIndex ) {
+			return { line: i + 1, column: charIndex - lineStart };
+		}
+
+		lineStart = lineEnd;
+	}
+
+	throw new Error( 'Could not determine location of character' );
+};

--- a/test/generateSourceMap/index.js
+++ b/test/generateSourceMap/index.js
@@ -1,66 +1,97 @@
 var assert = require( 'assert' );
 var sander = require( 'sander' );
+var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
+var getLocation = require( './getLocation' );
 var rcu = require( '../rcu' );
 
 describe( 'rcu.generateSourceMap()', function () {
-	it( 'generates a sourcemap', function () {
+	it( 'generates a hi-res sourcemap', function () {
 		return sander.readFile( __dirname, 'samples/foo.html' ).then( String ).then( function ( foo ) {
 			var definition = rcu.parse( foo );
-			var sourceMap = rcu.generateSourceMap( definition, {
-				source: 'foo.html',
-				file: 'foo.js'
-			});
 
-			assert.equal( sourceMap.version, 3 );
-			assert.equal( sourceMap.file, 'foo.js' );
-			assert.deepEqual( sourceMap.sources, [ 'foo.html' ]);
-			assert.deepEqual( sourceMap.sourcesContent, [ foo ]);
-			assert.deepEqual( sourceMap.names, []);
-			assert.deepEqual( sourceMap.mappings, 'AAEQ;AACR;AACA;AACA;AACA;AACA;AACA' );
-		});
-	});
+			var offset = 10;
+			var generated = new Array( offset + 1 ).join( '\n' ) + definition.script;
 
-	it( 'generates a sourcemap with offset', function () {
-		return sander.readFile( __dirname, 'samples/foo.html' ).then( String ).then( function ( foo ) {
-			var definition = rcu.parse( foo );
 			var sourceMap = rcu.generateSourceMap( definition, {
+				hires: true,
 				offset: 10,
 				source: 'foo.html',
 				file: 'foo.js'
 			});
 
+			var smc = new SourceMapConsumer( sourceMap );
+
+			var generatedLoc = getLocation( generated, generated.indexOf( 'log' ) );
+			var expectedLoc = getLocation( foo, foo.indexOf( 'log' ) );
+			var actualLoc = smc.originalPositionFor( generatedLoc );
+
+			assert.equal( actualLoc.line, expectedLoc.line );
+			assert.equal( actualLoc.column, expectedLoc.column );
+
+			generatedLoc = getLocation( generated, generated.indexOf( 'alert' ) );
+			expectedLoc = getLocation( foo, foo.indexOf( 'alert' ) );
+			actualLoc = smc.originalPositionFor( generatedLoc );
+
+			assert.equal( actualLoc.line, expectedLoc.line );
+			assert.equal( actualLoc.column, expectedLoc.column );
+
+			assert.deepEqual( sourceMap.mappings, ';;;;;;;;;;AAEQ;AACR,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACrB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACtB,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AAC/B;AACA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AAChB,CAAC,CAAC;AACF,CAAC,CAAC;AACF' );
+		});
+	});
+
+	it( 'generates a lo-res sourcemap', function () {
+		return sander.readFile( __dirname, 'samples/foo.html' ).then( String ).then( function ( foo ) {
+			var definition = rcu.parse( foo );
+			var sourceMap = rcu.generateSourceMap( definition, {
+				source: 'foo.html',
+				file: 'foo.js',
+				hires: false
+			});
+
 			assert.equal( sourceMap.version, 3 );
 			assert.equal( sourceMap.file, 'foo.js' );
 			assert.deepEqual( sourceMap.sources, [ 'foo.html' ]);
 			assert.deepEqual( sourceMap.sourcesContent, [ foo ]);
 			assert.deepEqual( sourceMap.names, []);
-			assert.deepEqual( sourceMap.mappings, ';;;;;;;;;;AAEQ;AACR;AACA;AACA;AACA;AACA;AACA' );
+			assert.deepEqual( sourceMap.mappings, 'AAEQ;AACR;AACA;AACA;AACA;AACA;AACA;AACA;AACA' );
+		});
+	});
+
+	it( 'generates a lo-res sourcemap with offset', function () {
+		return sander.readFile( __dirname, 'samples/foo.html' ).then( String ).then( function ( foo ) {
+			var definition = rcu.parse( foo );
+			var sourceMap = rcu.generateSourceMap( definition, {
+				offset: 10,
+				source: 'foo.html',
+				file: 'foo.js',
+				hires: false
+			});
+
+			assert.equal( sourceMap.version, 3 );
+			assert.equal( sourceMap.file, 'foo.js' );
+			assert.deepEqual( sourceMap.sources, [ 'foo.html' ]);
+			assert.deepEqual( sourceMap.sourcesContent, [ foo ]);
+			assert.deepEqual( sourceMap.names, []);
+			assert.deepEqual( sourceMap.mappings, ';;;;;;;;;;AAEQ;AACR;AACA;AACA;AACA;AACA;AACA;AACA;AACA' );
 		});
 	});
 
 	it( 'warns on deprecated options.padding, and fixes it after initial warning', function () {
 		return sander.readFile( __dirname, 'samples/foo.html' ).then( String ).then( function ( foo ) {
-			var log = global.console.log;
-			var logged = false;
+			var warn = global.console.warn;
+			var warned = 0;
 
-			global.console.log = function ( msg ) {
+			global.console.warn = function ( msg ) {
 				assert.ok( /deprecated/.test( msg ) );
-				logged = true;
-			}
+				warned += 1;
+			};
 
 			function go () {
-				var sourceMap = rcu.generateSourceMap( definition, {
+				rcu.generateSourceMap( definition, {
 					padding: 10,
 					source: 'foo.html',
 					file: 'foo.js'
 				});
-
-				assert.equal( sourceMap.version, 3 );
-				assert.equal( sourceMap.file, 'foo.js' );
-				assert.deepEqual( sourceMap.sources, [ 'foo.html' ]);
-				assert.deepEqual( sourceMap.sourcesContent, [ foo ]);
-				assert.deepEqual( sourceMap.names, []);
-				assert.deepEqual( sourceMap.mappings, ';;;;;;;;;;AAEQ;AACR;AACA;AACA;AACA;AACA;AACA' );
 			}
 
 			var definition = rcu.parse( foo );
@@ -68,9 +99,9 @@ describe( 'rcu.generateSourceMap()', function () {
 			go();
 			go();
 
-			assert.ok( logged );
+			assert.equal( warned, 1 );
 
-			global.console.log = log;
+			global.console.warn = warn;
 		});
 	});
 });

--- a/test/generateSourceMap/samples/foo.html
+++ b/test/generateSourceMap/samples/foo.html
@@ -4,6 +4,8 @@
 	component.exports = {
 		oninit: function () {
 			console.log( 'hello world' );
+
+			alert( 'ok' );
 		}
 	};
 </script>


### PR DESCRIPTION
Some sourcemap tooling only works if maps are accurate to the character, rather than to the line. With this PR `rcu.generateSourceMap` creates a segment for each character by default – the resulting sourcemap is considerably bulkier but I reckon it's worth it