### PR TITLE
remove tippex dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "repository": "https://github.com/ractivejs/rcu",
   "dependencies": {
     "eval2": "^0.3.0",
-    "tippex": "^1.1.0",
     "vlq": "^0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
hi @Rich-Harris 
I had some problems with the tippex dependency after I upgradied rcu. I found it easy to just use string replacement to replace comments with whitespace. all tests pass and commented out requires are not included (which was where I began in the first place)

cheers