### PR TITLE
Add support for 0.8-edge after conditional attributes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
         "space-before-blocks": [ 2, "always" ],
         "space-before-function-paren": [ 2, "always" ],
         "no-mixed-spaces-and-tabs": [ 2, "smart-tabs" ],
-        "no-cond-assign": [ 0 ]
+        "no-cond-assign": [ 0 ],
+        "no-console": 0
     },
     "env": {
         "es6": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,7 @@
         "space-before-blocks": [ 2, "always" ],
         "space-before-function-paren": [ 2, "always" ],
         "no-mixed-spaces-and-tabs": [ 2, "smart-tabs" ],
-        "no-cond-assign": [ 0 ],
-        "no-console": 0
+        "no-cond-assign": [ 0 ]
     },
     "env": {
         "es6": true,

--- a/src/parse.js
+++ b/src/parse.js
@@ -18,7 +18,7 @@ export default function parse ( source ) {
 	});
 
 	if ( parsed.v !== TEMPLATE_VERSION ) {
-		console.warn( `Mismatched template version (expected ${TEMPLATE_VERSION}, got ${parsed.v})! Please ensure you are using the latest version of Ractive.js in your build process as well as in your app` );
+		console.warn( `Mismatched template version (expected ${TEMPLATE_VERSION}, got ${parsed.v})! Please ensure you are using the latest version of Ractive.js in your build process as well as in your app` ); // eslint-disable-line no-console
 	}
 
 	let links = [];

--- a/test/generateSourceMap/index.js
+++ b/test/generateSourceMap/index.js
@@ -82,8 +82,7 @@ describe( 'rcu.generateSourceMap()', function () {
 			var warned = 0;
 
 			global.console.warn = function ( msg ) {
-				assert.ok( /deprecated/.test( msg ) );
-				warned += 1;
+				if ( /deprecated/.test( msg ) ) warned += 1;
 			};
 
 			function go () {

--- a/test/parse/index.js
+++ b/test/parse/index.js
@@ -12,6 +12,7 @@ describe( 'rcu.parse()', function () {
 				var actual = rcu.parse( definition );
 
 				return sander.readFile( __dirname, 'output', output ).then( String ).then( JSON.parse ).then( function ( expected ) {
+					if ( expected.template ) expected.template.v = actual.template.v;
 					assert.deepEqual( actual, expected );
 				});
 			});


### PR DESCRIPTION
This adds support for handling the slightly adjusted template format introduced by conditional attribute support in 0.8. It also changes the template version mismatch into a warning, since it can now handle more than one template version.

The testing here is a little bit weird. I'm not really sure the best way to go about testing two different versions of ractive without doing some extra scripting around the tests. For now, I've hacked the tests a bit and run them with both 0.7.3 and edge. Suggestions welcome!