### PR TITLE
Fix builds on Windows by forcing Unix style EndOfLines on the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use Unix EOLs by default even on Windows because the 'expected output' json files in tests can't be made dynamic, so they use "\n" as convention
+* text=auto eol=lf


### PR DESCRIPTION
Fix by using the [per repository .gitattributes overrides](https://help.github.com/articles/dealing-with-line-endings/#per-repository-settings)

Rationale: The Windows' default is 'auto', which will result in checking out CRLF and, as a result, eslint and parser tests complaining. None of them can be made dynamic, so this is the only real option.

Windows editors support Unix EOLs just fine, so this should really be OK. The worst that can happen is someone that didn't run tests commits Windows EOLs in his fork, which will get caught by the eslint and tests checks on the pull requests.
