### PR TITLE
Update Ractive dependency to ^0.8.0 & rcu version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcu",
-  "version": "0.9.0-edge1",
+  "version": "0.9.0",
   "description": "Utilities for implementing Ractive.js component loaders",
   "license": "MIT",
   "repository": "https://github.com/ractivejs/rcu",
@@ -8,7 +8,7 @@
     "eslint": "^2.8.0",
     "eval2": "^0.3.3",
     "mocha": "^2.4.5",
-    "ractive": "github:ractivejs/ractive#edge",
+    "ractive": "^0.8.0",
     "resolve": "^1.1.7",
     "rollup": "^0.25.8",
     "rollup-plugin-buble": "^0.5.0",


### PR DESCRIPTION
Hi. Should this be updated now 0.8.x is out? Thanks!